### PR TITLE
FIx kernel building instructions

### DIFF
--- a/MMI-QSAS30.62-24-3.txt
+++ b/MMI-QSAS30.62-24-3.txt
@@ -9,13 +9,13 @@ mkdir -vp  $my_top_dir/prebuilts/clang/host
 
 cd $my_top_dir/prebuilts/clang/host
 
-git clone https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86
+git clone https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86 -b pie-release --depth=1
 
 mkdir -vp  $my_top_dir/prebuilts/gcc/linux-x86/aarch64
 
 cd $my_top_dir/prebuilts/gcc/linux-x86/aarch64
 
-git clone https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9
+git clone https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9 -b pie-release --depth=1
 
 Download kernel source code. Rename kernel-* folder to $my_top_dir/kernel 
 
@@ -41,8 +41,8 @@ cat kernel/exynos9610/arch/arm64/configs/erd9610_Q_defconfig kernel/exynos9610/a
 
 cp $kernel_out_dir/mapphone_defconfig $kernel_out_dir/.config 
 
-make -j8 -C kernel/exynos9610 O=$kernel_out_dir ARCH=arm64 CROSS_COMPILE=$cross defoldconfig
+make -j8 -C kernel O=$kernel_out_dir ARCH=arm64 CROSS_COMPILE=$cross defoldconfig
 
-make -j8 -C kernel/exynos9610 O=$kernel_out_dir ARCH=arm64 CROSS_COMPILE=$cross CLANG_TRIPLE=aarch64-linux-gnu- CC=$clang LLVM_AR=$llvm_ar LLVM_DIS=$llvm_dis LTO_LLVM_LIB_BASE=$lto_llvm -j8
+make -j8 -C kernel O=$kernel_out_dir ARCH=arm64 CROSS_COMPILE=$cross CLANG_TRIPLE=aarch64-linux-gnu- CC=$clang LLVM_AR=$llvm_ar LLVM_DIS=$llvm_dis LTO_LLVM_LIB_BASE=$lto_llvm -j8
 
-make -j8 -C kernel/exynos9610 ARCH=arm64 CROSS_COMPILE=$cross distclean
+make -j8 -C kernel ARCH=arm64 CROSS_COMPILE=$cross distclean


### PR DESCRIPTION
1: Clone only the needed android 9 clang from the pie-release branch
2: The cloned repo is pretty big, but we don't need the commit history so we use --depth=1 to skip all things we don't need reducing the cloning time
3: There was a small typo in the make commands, based on the instructions above the kernel's directory is `$my_top_dir/kernel` and not `$my_top_dir/kernel/exynos9610`